### PR TITLE
Fix: Update the go install instructions in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ You have a project with dozens of tasks. Running them one at a time is slow. Run
 ## Quick Start
 
 ```bash
-# Install
-go install github.com/cloud-shuttle/drover@latest
+# Install (note: use the full package path including /cmd/drover)
+go install github.com/cloud-shuttle/drover/cmd/drover@latest
+
+# Add Go's bin directory to your PATH if not already configured
+export PATH=$PATH:$HOME/go/bin
 
 # Initialize in your project
 cd my-project
@@ -72,7 +75,7 @@ go build -o drover .
 ### With Go Install
 
 ```bash
-go install github.com/cloud-shuttle/drover@latest
+go install github.com/cloud-shuttle/drover/cmd/drover@latest
 ```
 
 ## Commands


### PR DESCRIPTION
Following the quick start guide, I got the error:
```
go: github.com/cloud-shuttle/drover@latest: module github.com/cloud-shuttle/drover@latest found (v0.1.0), but does not contain package github.com/cloud-shuttle/drover
```
I think the path needs to include the cmd/drover sub directory for a CLI install 

Also added a note about the Go binary path for if drover can't be found after install